### PR TITLE
Add function name support for actions

### DIFF
--- a/.storybook/stories.js
+++ b/.storybook/stories.js
@@ -20,4 +20,8 @@ storiesOf('Button', module)
       onClick={() => action('circular')(circular)}>
       Circular Payload
     </button>;
+  })
+  .add('Function Name', () => {
+    const fn = action('fnName');
+    return <button onClick={fn}>Action.name: {fn.name}</button>
   });

--- a/dist/components/ActionLogger/index.js
+++ b/dist/components/ActionLogger/index.js
@@ -32,7 +32,7 @@ var ActionLogger = function (_Component) {
   function ActionLogger() {
     _classCallCheck(this, ActionLogger);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(ActionLogger).apply(this, arguments));
+    return _possibleConstructorReturn(this, (ActionLogger.__proto__ || Object.getPrototypeOf(ActionLogger)).apply(this, arguments));
   }
 
   _createClass(ActionLogger, [{

--- a/dist/containers/ActionLogger/index.js
+++ b/dist/containers/ActionLogger/index.js
@@ -34,7 +34,7 @@ var ActionLogger = function (_React$Component) {
   _inherits(ActionLogger, _React$Component);
 
   function ActionLogger(props) {
-    var _Object$getPrototypeO;
+    var _ref;
 
     _classCallCheck(this, ActionLogger);
 
@@ -42,7 +42,7 @@ var ActionLogger = function (_React$Component) {
       args[_key - 1] = arguments[_key];
     }
 
-    var _this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(ActionLogger)).call.apply(_Object$getPrototypeO, [this, props].concat(args)));
+    var _this = _possibleConstructorReturn(this, (_ref = ActionLogger.__proto__ || Object.getPrototypeOf(ActionLogger)).call.apply(_ref, [this, props].concat(args)));
 
     _this.state = { actions: [] };
     _this._actionListener = function (action) {

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -28,7 +28,8 @@ function _format(arg) {
 }
 
 function action(name) {
-  return function () {
+
+  var handler = function handler() {
     for (var _len = arguments.length, _args = Array(_len), _key = 0; _key < _len; _key++) {
       _args[_key] = arguments[_key];
     }
@@ -41,6 +42,16 @@ function action(name) {
       data: { name: name, args: args }
     });
   };
+
+  // some day when {[name]: function() {}} syntax is not transpiled by babel
+  // we can get rid of this eval as by ES2015 spec the above function gets the
+  // name `name`, but babel transpiles to Object.defineProperty which doesn't do
+  // the same.
+  //
+  // Ref: https://bocoup.com/weblog/whats-in-a-function-name
+  var fnName = name.replace(/\W+/g, '_');
+  var named = eval('(function ' + fnName + '() { return handler.apply(this, arguments) })');
+  return named;
 }
 
 function decorateAction(decorators) {

--- a/src/preview.js
+++ b/src/preview.js
@@ -10,7 +10,8 @@ function _format(arg) {
 }
 
 export function action(name) {
-  return function (..._args) {
+
+  const handler = function (..._args) {
     const args = Array.from(_args).map(_format);
     const channel = addons.getChannel();
     const randomId = Math.random().toString(16).slice(2);
@@ -19,6 +20,16 @@ export function action(name) {
       data: { name, args },
     });
   };
+
+  // some day when {[name]: function() {}} syntax is not transpiled by babel
+  // we can get rid of this eval as by ES2015 spec the above function gets the
+  // name `name`, but babel transpiles to Object.defineProperty which doesn't do
+  // the same.
+  //
+  // Ref: https://bocoup.com/weblog/whats-in-a-function-name
+  const fnName = name.replace(/\W+/g,'_');
+  const named = eval(`(function ${fnName}() { return handler.apply(this, arguments) })`)
+  return named
 }
 
 export function decorateAction(decorators) {


### PR DESCRIPTION
I was trying out the `react-storybook-addon-info` addon, and noted that `action('onChange')` had the function name of `anonymous`...

Using this patch:

![image](https://cloud.githubusercontent.com/assets/549355/19605403/d216acf4-9787-11e6-86ee-b5cd3c2ce7ab.png)
