### PR TITLE
Support actions without names

### DIFF
--- a/dist/preview.js
+++ b/dist/preview.js
@@ -49,7 +49,7 @@ function action(name) {
   // the same.
   //
   // Ref: https://bocoup.com/weblog/whats-in-a-function-name
-  var fnName = name.replace(/\W+/g, '_');
+  var fnName = name ? name.replace(/\W+/g, '_') : 'action';
   var named = eval('(function ' + fnName + '() { return handler.apply(this, arguments) })');
   return named;
 }

--- a/src/preview.js
+++ b/src/preview.js
@@ -27,7 +27,7 @@ export function action(name) {
   // the same.
   //
   // Ref: https://bocoup.com/weblog/whats-in-a-function-name
-  const fnName = name.replace(/\W+/g,'_');
+  const fnName = name ? name.replace(/\W+/g,'_') : 'action';
   const named = eval(`(function ${fnName}() { return handler.apply(this, arguments) })`)
   return named
 }


### PR DESCRIPTION
v1.1.2 breaks the storybook when actions are used without names. Fix this so actions can be used without names as before.

Related Issue: https://github.com/storybooks/storybook-addon-actions/issues/29