### PR TITLE
Use strict equality

### DIFF
--- a/dist/containers/ActionLogger/index.js
+++ b/dist/containers/ActionLogger/index.js
@@ -59,7 +59,7 @@ var ActionLogger = function (_React$Component) {
       });
       var actions = [].concat(_toConsumableArray(this.state.actions));
       var previous = actions.length && actions[0];
-      if (previous && (0, _deepEqual2.default)(previous.data, action.data)) {
+      if (previous && (0, _deepEqual2.default)(previous.data, action.data, { strict: true })) {
         previous.count++;
       } else {
         action.count = 1;

--- a/src/containers/ActionLogger/index.js
+++ b/src/containers/ActionLogger/index.js
@@ -14,7 +14,7 @@ export default class ActionLogger extends React.Component {
     action.data.args = action.data.args.map(arg => JSON.parse(arg));
     const actions = [...this.state.actions];
     const previous = actions.length && actions[0];
-    if (previous && deepEqual(previous.data, action.data)) {
+    if (previous && deepEqual(previous.data, action.data, { strict: true })) {
       previous.count++;
     } else {
       action.count = 1;


### PR DESCRIPTION
Changes proposed in this Pull Request:
- Use [strict equality](https://www.npmjs.com/package/deep-equal#deepequala-b-opts) to distinguish `0` from an empty string (`''`)

Steps to reproduce the issue:
- Log action with data: `'foo'`
- `['foo']` is logged in
- Log action with data: `0`
- `[0]` is logged in
- Log action with data: `''`
- `[0]` is logged in